### PR TITLE
2023-07-14: v1.0.4

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,8 @@
 =========================================================================
 Date                Version     Description
 =========================================================================
+2023-07-14: v1.0.4 : Fix 'command doesn't exist' error when Magento payment_action does not save.
+
 2023-07-13: v1.0.3 : Refactor to use common classes and composer.
                      Bugs fixes and improvements.
 

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -33,8 +33,8 @@
                     <source_model>NetworkInternational\NGenius\Model\Config\NgeniusPaymentAction</source_model>
                     <config_path>payment/ngeniusonline/ngenius_payment_action</config_path>
                 </field>
-                <field id="payment_action" translate="label" type="select" sortOrder="6" showInDefault="0" showInWebsite="0" showInStore="0" >
-                    <label>Payment Action</label>
+                <field id="payment_action" translate="label" type="select" sortOrder="6" showInDefault="1" showInWebsite="1" showInStore="0" >
+                    <label>Magento Order Action</label>
                     <source_model>NetworkInternational\NGenius\Model\Config\PaymentAction</source_model>
                     <config_path>payment/ngeniusonline/payment_action</config_path>
                 </field>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,5 +1,5 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="NetworkInternational_NGenius" setup_version="1.0.3" >
+    <module name="NetworkInternational_NGenius" setup_version="1.0.4" >
         <sequence>
             <module name="Magento_Sales" />
             <module name="Magento_Payment" />


### PR DESCRIPTION
Fix 'command doesn't exist' error when Magento payment_action does not save.