### PR TITLE
2024-03-18: v1.1.4

### DIFF
--- a/Block/Info.php
+++ b/Block/Info.php
@@ -15,7 +15,8 @@ class Info extends ConfigurableInfo
     /**
      * Returns label
      *
-     * @param  string $field
+     * @param string $field
+     *
      * @return Phrase
      */
     protected function getLabel($field)

--- a/Block/Ngenius.php
+++ b/Block/Ngenius.php
@@ -55,33 +55,34 @@ class Ngenius extends ConfigurableInfo
     /**
      * Ngenius constructor.
      *
-     * @param OrderInterface       $orderInterface
-     * @param TokenRequest         $tokenRequest
+     * @param OrderInterface $orderInterface
+     * @param TokenRequest $tokenRequest
      * @param ScopeConfigInterface $scopeConfig
-     * @param Session              $checkoutSession
-     * @param PaymentRequest       $paymentRequest
-     * @param PaymentTransaction   $paymentTransaction
+     * @param Session $checkoutSession
+     * @param PaymentRequest $paymentRequest
+     * @param PaymentTransaction $paymentTransaction
      */
     public function __construct(
-        OrderInterface       $orderInterface,
-        TokenRequest         $tokenRequest,
+        OrderInterface $orderInterface,
+        TokenRequest $tokenRequest,
         ScopeConfigInterface $scopeConfig,
-        Session              $checkoutSession,
-        PaymentRequest       $paymentRequest,
-        PaymentTransaction   $paymentTransaction
+        Session $checkoutSession,
+        PaymentRequest $paymentRequest,
+        PaymentTransaction $paymentTransaction
     ) {
-        $this->checkoutSession      = $checkoutSession;
-        $this->orderFactory         = $orderInterface;
-        $this->tokenRequest         = $tokenRequest;
-        $this->_scopeConfig         = $scopeConfig;
-        $this->paymentRequest       = $paymentRequest;
-        $this->paymentTransaction   = $paymentTransaction;
+        $this->checkoutSession    = $checkoutSession;
+        $this->orderFactory       = $orderInterface;
+        $this->tokenRequest       = $tokenRequest;
+        $this->_scopeConfig       = $scopeConfig;
+        $this->paymentRequest     = $paymentRequest;
+        $this->paymentTransaction = $paymentTransaction;
     }
 
     /**
      * Retrieves Pay Page URL
      *
-     * @param  string $ngeniusPaymentAction
+     * @param string $ngeniusPaymentAction
+     *
      * @return array
      * @throws CouldNotSaveException
      * @throws NoSuchEntityException
@@ -89,7 +90,7 @@ class Ngenius extends ConfigurableInfo
     public function getPaymentUrl(string $ngeniusPaymentAction): array
     {
         $checkoutSession = $this->checkoutSession;
-        $return = [];
+        $return          = [];
 
         if ($incrementId = $checkoutSession->getLastRealOrderId()) {
             $order = $this->orderFactory->loadByIncrementId($incrementId);
@@ -98,7 +99,6 @@ class Ngenius extends ConfigurableInfo
             $amount  = $order->getGrandTotal() * 100;
 
             if (in_array($ngeniusPaymentAction, $this->allowedActions)) {
-
                 $requestData = [
                     'token'   => $this->tokenRequest->getAccessToken($storeId),
                     'request' => $this->paymentRequest->getBuildArray(

--- a/Controller/Adminhtml/Core/Report.php
+++ b/Controller/Adminhtml/Core/Report.php
@@ -17,7 +17,7 @@ class Report extends \Magento\Backend\App\Action
     /**
      * Report constructor.
      *
-     * @param Context     $context
+     * @param Context $context
      * @param PageFactory $resultPageFactory
      */
     public function __construct(
@@ -37,6 +37,7 @@ class Report extends \Magento\Backend\App\Action
     {
         $resultPage = $this->resultPageFactory->create();
         $resultPage->getConfig()->getTitle()->prepend((__('N-Genius Report')));
+
         return $resultPage;
     }
 }

--- a/Controller/NGeniusOnline/Redirect.php
+++ b/Controller/NGeniusOnline/Redirect.php
@@ -59,13 +59,13 @@ class Redirect implements HttpGetActionInterface
     /**
      * Redirect constructor.
      *
-     * @param ResultFactory           $resultRedirect
-     * @param Session                 $checkoutSession
-     * @param LayoutFactory           $layoutFactory
+     * @param ResultFactory $resultRedirect
+     * @param Session $checkoutSession
+     * @param LayoutFactory $layoutFactory
      * @param CartRepositoryInterface $quoteRepository
-     * @param ManagerInterface        $messageManager
-     * @param ScopeConfigInterface    $scopeConfig
-     * @param Config                  $config
+     * @param ManagerInterface $messageManager
+     * @param ScopeConfigInterface $scopeConfig
+     * @param Config $config
      */
     public function __construct(
         ResultFactory $resultRedirect,
@@ -74,7 +74,7 @@ class Redirect implements HttpGetActionInterface
         CartRepositoryInterface $quoteRepository,
         ManagerInterface $messageManager,
         ScopeConfigInterface $scopeConfig,
-        Config               $config,
+        Config $config,
     ) {
         $this->resultRedirect  = $resultRedirect;
         $this->checkoutSession = $checkoutSession;
@@ -93,7 +93,7 @@ class Redirect implements HttpGetActionInterface
      */
     public function execute()
     {
-        $order   = $this->checkoutSession->getLastRealOrder();
+        $order = $this->checkoutSession->getLastRealOrder();
 
         $storeId = $order->getStoreId();
 
@@ -108,8 +108,8 @@ class Redirect implements HttpGetActionInterface
         }
 
         $resultRedirectFactory = $this->resultRedirect->create(ResultFactory::TYPE_REDIRECT);
-        $initialStatus = $this->config->getInitialOrderStatus($storeId);
-        $order = $this->checkoutSession->getLastRealOrder();
+        $initialStatus         = $this->config->getInitialOrderStatus($storeId);
+        $order                 = $this->checkoutSession->getLastRealOrder();
         $order->setState($initialStatus);
         $order->setStatus($initialStatus);
         $order->addStatusHistoryComment(
@@ -122,7 +122,7 @@ class Redirect implements HttpGetActionInterface
             $exception = $url['exception'];
             $this->messageManager->addExceptionMessage($exception, $exception->getMessage());
             $resultRedirectFactory->setPath(self::CARTPATH);
-            $order   = $this->checkoutSession->getLastRealOrder();
+            $order = $this->checkoutSession->getLastRealOrder();
             $order->addCommentToStatusHistory($exception->getMessage());
             $order->setStatus('ngenius_failed');
             $order->setState(Order::STATE_CLOSED);

--- a/Cron/UpdateOrder.php
+++ b/Cron/UpdateOrder.php
@@ -127,8 +127,8 @@ class UpdateOrder
             $_transactionBuilder,
             $orderRepository
         );
-        $this->state = $state;
-        $this->logger = $logger;
+        $this->state               = $state;
+        $this->logger              = $logger;
     }
 
     /**

--- a/Gateway/Command/CaptureStrategyCommand.php
+++ b/Gateway/Command/CaptureStrategyCommand.php
@@ -42,7 +42,7 @@ class CaptureStrategyCommand implements CommandInterface
     public function execute(array $commandSubject)
     {
         $paymentDO = SubjectReader::readPayment($commandSubject);
-        $command = $this->getCommand($paymentDO);
+        $command   = $this->getCommand($paymentDO);
         if ($command && $command !== "authorize" && $command !== "order") {
             $this->commandPool->get($command)->execute($commandSubject);
         } else {
@@ -56,7 +56,8 @@ class CaptureStrategyCommand implements CommandInterface
     /**
      * Gets command name.
      *
-     * @param  PaymentDataObjectInterface $paymentDO
+     * @param PaymentDataObjectInterface $paymentDO
+     *
      * @return string
      */
     private function getCommand(PaymentDataObjectInterface $paymentDO)

--- a/Gateway/Config/Config.php
+++ b/Gateway/Config/Config.php
@@ -206,6 +206,7 @@ class Config extends \Magento\Payment\Gateway\Config\Config
      * @param int|null $storeId
      * @param string $action
      * @param string $currencyCode
+     *
      * @return string
      */
     public function getOrderRequestURL(?int $storeId, string $action, string $currencyCode): string

--- a/Gateway/Http/Client/PaymentTransaction.php
+++ b/Gateway/Http/Client/PaymentTransaction.php
@@ -56,12 +56,12 @@ class PaymentTransaction implements ClientInterface
     /**
      * PaymentTransaction constructor.
      *
-     * @param Logger                   $logger
-     * @param Session                  $checkoutSession
-     * @param ManagerInterface         $messageManager
-     * @param Config                   $config
-     * @param StoreManagerInterface    $storeManager
-     * @param CoreFactory              $coreFactory
+     * @param Logger $logger
+     * @param Session $checkoutSession
+     * @param ManagerInterface $messageManager
+     * @param Config $config
+     * @param StoreManagerInterface $storeManager
+     * @param CoreFactory $coreFactory
      * @param OrderRepositoryInterface $orderRepository
      */
     public function __construct(
@@ -73,13 +73,13 @@ class PaymentTransaction implements ClientInterface
         CoreFactory $coreFactory,
         OrderRepositoryInterface $orderRepository
     ) {
-        $this->logger = $logger;
+        $this->logger          = $logger;
         $this->checkoutSession = $checkoutSession;
-        $this->orderStatus = DataPatch::getStatuses();
-        $this->messageManager = $messageManager;
-        $this->config = $config;
-        $this->storeManager = $storeManager;
-        $this->coreFactory = $coreFactory;
+        $this->orderStatus     = DataPatch::getStatuses();
+        $this->messageManager  = $messageManager;
+        $this->config          = $config;
+        $this->storeManager    = $storeManager;
+        $this->coreFactory     = $coreFactory;
         $this->orderRepository = $orderRepository;
     }
 
@@ -87,24 +87,25 @@ class PaymentTransaction implements ClientInterface
      * Places request to gateway. Returns result as ENV array
      *
      * @param array|TransferInterface $requestData
+     *
      * @return array|null
      * @throws NoSuchEntityException
      */
     public function placeRequest(array|TransferInterface $requestData): ?array
     {
         if (is_array($requestData)) {
-            $token = $requestData['token'];
-            $url = $requestData['request']['uri'];
-            $data = $requestData['request']['data'];
+            $token  = $requestData['token'];
+            $url    = $requestData['request']['uri'];
+            $data   = $requestData['request']['data'];
             $method = $requestData['request']['method'];
         } else {
-            $token = $requestData->getHeaders()['Token'];
-            $url = $requestData->getUri();
-            $data = $requestData->getBody();
+            $token  = $requestData->getHeaders()['Token'];
+            $url    = $requestData->getUri();
+            $data   = $requestData->getBody();
             $method = $requestData->getMethod();
         }
 
-        $storeId = $this->storeManager->getStore()->getId();
+        $storeId             = $this->storeManager->getStore()->getId();
         $ngeniusHttpTransfer = new NgeniusHTTPTransfer($url, $this->config->getHttpVersion($storeId));
         $ngeniusHttpTransfer->setPaymentHeaders($token);
         $ngeniusHttpTransfer->setMethod($method);
@@ -130,7 +131,8 @@ class PaymentTransaction implements ClientInterface
     /**
      * Processing of API response
      *
-     * @param  string $responseEnc
+     * @param string $responseEnc
+     *
      * @return null|array
      * @throws Exception
      */
@@ -145,19 +147,20 @@ class PaymentTransaction implements ClientInterface
             $currencyCode = $response->amount->currencyCode;
 
             $data['reference'] = $response->reference ?? '';
-            $data['action'] = $response->action ?? '';
-            $data['amount'] = ValueFormatter::formatOrderStatusAmount($currencyCode, $amount)/100;
-            $data['state'] = $response->_embedded->payment[0]->state ?? '';
-            $data['status'] = $this->orderStatus[0]['status'];
+            $data['action']    = $response->action ?? '';
+            $data['amount']    = ValueFormatter::formatOrderStatusAmount($currencyCode, $amount) / 100;
+            $data['state']     = $response->_embedded->payment[0]->state ?? '';
+            $data['status']    = $this->orderStatus[0]['status'];
             $data['order_id']  = $data['last_real_order_id'];
             $data['entity_id'] = $data['last_order_id'];
-            $data['currency'] = $response->amount->currencyCode;
+            $data['currency']  = $response->amount->currencyCode;
 
             $model = $this->coreFactory->create();
             $model->addData($data);
             $model->save();
 
             $this->checkoutSession->setPaymentURL($response->_links->payment->href);
+
             return ['payment_url' => $response->_links->payment->href];
         } elseif (isset($response->errors)) {
             return ['message' => 'Message: ' . $response->message . ': ' . $response->errors[0]->message];

--- a/Gateway/Http/Client/TransactionCapture.php
+++ b/Gateway/Http/Client/TransactionCapture.php
@@ -31,7 +31,10 @@ class TransactionCapture extends PaymentTransaction
             $lastTransaction  = $transaction_data['last_transaction'];
             $captured_amt     = 0;
             $currencyCode     = $lastTransaction['amount']['currencyCode'] ?? '';
-            $amount           = ($amount > 0) ? ValueFormatter::formatOrderStatusAmount($currencyCode, ($amount / 100)) : 0;
+            $amount           = ($amount > 0) ? ValueFormatter::formatOrderStatusAmount(
+                $currencyCode,
+                ($amount / 100)
+            ) : 0;
 
             if (isset($lastTransaction['state'])
                 && ($lastTransaction['state'] == 'SUCCESS')
@@ -89,6 +92,7 @@ class TransactionCapture extends PaymentTransaction
 
             return end($transactionArr);
         }
+
         return false;
     }
 
@@ -96,6 +100,7 @@ class TransactionCapture extends PaymentTransaction
      * Gets NGenius payment data
      *
      * @param array $response
+     *
      * @return array
      */
     public function getTransactionData(mixed $response): mixed

--- a/Gateway/Http/Client/TransactionFetch.php
+++ b/Gateway/Http/Client/TransactionFetch.php
@@ -7,7 +7,8 @@ class TransactionFetch extends PaymentTransaction
     /**
      * Processing of API response
      *
-     * @param  array $responseEnc
+     * @param array $responseEnc
+     *
      * @return array|null
      */
     protected function postProcess($responseEnc): ?array

--- a/Gateway/Http/Client/TransactionRefund.php
+++ b/Gateway/Http/Client/TransactionRefund.php
@@ -43,12 +43,12 @@ class TransactionRefund extends PaymentTransaction
             $transactionId     = $refund_data['transactionId'] ?? $response['reference'];
 
             $collection = $this->coreFactory->create()
-                ->getCollection()
-                ->addFieldToFilter('reference', $response['orderReference']);
+                                            ->getCollection()
+                                            ->addFieldToFilter('reference', $response['orderReference']);
 
-            $orderItem  = $collection->getFirstItem();
+            $orderItem = $collection->getFirstItem();
 
-            $state      = $response['state'] ?? '';
+            $state = $response['state'] ?? '';
 
             if ($state === 'REVERSED') {
                 $captured_amt = (int)($orderItem->getData('captured_amt') * 100);
@@ -124,6 +124,7 @@ class TransactionRefund extends PaymentTransaction
      *
      * @param array $refund
      * @param float $refunded_amt
+     *
      * @return float|null
      */
     public function getAmountValue(array $refund, float $refunded_amt): ?float
@@ -135,6 +136,7 @@ class TransactionRefund extends PaymentTransaction
         ) {
             return (float)$refund['amount']['value'];
         }
+
         return null;
     }
 
@@ -142,6 +144,7 @@ class TransactionRefund extends PaymentTransaction
      * Gets NGenius payment refund data from response
      *
      * @param array $lastTransaction
+     *
      * @return array
      */
     public function getRefundData(mixed $lastTransaction): mixed
@@ -149,7 +152,7 @@ class TransactionRefund extends PaymentTransaction
         $refund_data = [];
         if (isset($lastTransaction['state'])
             && ($lastTransaction['state'] === 'SUCCESS'
-            || (isset($lastTransaction['_links'][self::NGENIUS_CUP_RESULTS])
+                || (isset($lastTransaction['_links'][self::NGENIUS_CUP_RESULTS])
                     && $lastTransaction['state'] === 'REQUESTED'))
             && isset($lastTransaction['amount']['value'])
         ) {

--- a/Gateway/Http/Client/TransactionVoid.php
+++ b/Gateway/Http/Client/TransactionVoid.php
@@ -92,8 +92,8 @@ class TransactionVoid extends PaymentTransaction
             return [];
         } else {
             $collection = $this->coreFactory->create()
-                ->getCollection()
-                ->addFieldToFilter('reference', $response['orderReference']);
+                                            ->getCollection()
+                                            ->addFieldToFilter('reference', $response['orderReference']);
 
             $orderItem = $collection->getFirstItem();
 
@@ -112,9 +112,9 @@ class TransactionVoid extends PaymentTransaction
             $payment->setAmountAuthorized(0.00);
 
             $transaction = $trans->setPayment($payment)
-                ->setOrder($order)
-                ->setFailSafe(true)
-                ->build(TransactionInterface::TYPE_VOID);
+                                 ->setOrder($order)
+                                 ->setFailSafe(true)
+                                 ->build(TransactionInterface::TYPE_VOID);
 
             $message = __('The authorised amount has been voided');
             $payment->addTransactionCommentsToOrder($transaction, $message);

--- a/Gateway/Http/TransferFactory.php
+++ b/Gateway/Http/TransferFactory.php
@@ -43,8 +43,8 @@ class TransferFactory implements TransferFactoryInterface
                 ->setMethod($request['request']['method'])
                 ->setHeaders(
                     [
-                                 'Authorization' => 'Bearer ' . $request['token'],
-                                 'Token'         => $request['token'],
+                        'Authorization' => 'Bearer ' . $request['token'],
+                        'Token'         => $request['token'],
                     ]
                 )
                 ->setUri($request['request']['uri'])
@@ -59,6 +59,7 @@ class TransferFactory implements TransferFactoryInterface
      *
      * @param array $request
      * @param string $apiKey
+     *
      * @return Transfer|TransferInterface|void
      */
     public function tokenBuild(array $request, string $apiKey)
@@ -69,8 +70,8 @@ class TransferFactory implements TransferFactoryInterface
                 ->setMethod($request['request']['method'])
                 ->setHeaders(
                     [
-                                 'Authorization' => 'Basic ' . $apiKey,
-                                 'Content-Type'  => 'application/vnd.ni-identity.v1+json',
+                        'Authorization' => 'Basic ' . $apiKey,
+                        'Content-Type'  => 'application/vnd.ni-identity.v1+json',
                     ]
                 )
                 ->setUri($request['request']['uri'])

--- a/Gateway/Request/CaptureRequest.php
+++ b/Gateway/Request/CaptureRequest.php
@@ -46,10 +46,10 @@ class CaptureRequest implements BuilderInterface
     /**
      * CaptureRequest constructor.
      *
-     * @param Config                $config
-     * @param TokenRequest          $tokenRequest
+     * @param Config $config
+     * @param TokenRequest $tokenRequest
      * @param StoreManagerInterface $storeManager
-     * @param CoreFactory           $coreFactory
+     * @param CoreFactory $coreFactory
      */
     public function __construct(
         Config $config,
@@ -85,11 +85,11 @@ class CaptureRequest implements BuilderInterface
         }
 
         $collection = $this->coreFactory->create()
-            ->getCollection()
-            ->addFieldToFilter('order_id', $order->getOrderIncrementId());
+                                        ->getCollection()
+                                        ->addFieldToFilter('order_id', $order->getOrderIncrementId());
         $orderItem  = $collection->getFirstItem();
 
-        $amount   = $this->formatPrice(SubjectReader::readAmount($buildSubject)) * 100;
+        $amount       = $this->formatPrice(SubjectReader::readAmount($buildSubject)) * 100;
         $currencyCode = $orderItem->getCurrency();
 
         ValueFormatter::formatCurrencyAmount($currencyCode, $amount);
@@ -99,13 +99,13 @@ class CaptureRequest implements BuilderInterface
                 'token'   => $this->tokenRequest->getAccessToken($storeId),
                 'request' => [
                     'data'   => [
-                        'amount' => [
+                        'amount'              => [
                             'currencyCode' => $currencyCode,
                             'value'        => $amount
                         ],
                         'merchantDefinedData' => [
-                            'pluginName' => 'magento-2',
-                            'pluginVersion' => '1.1.3'
+                            'pluginName'    => 'magento-2',
+                            'pluginVersion' => '1.1.4'
                         ]
                     ],
                     'method' => \Laminas\Http\Request::METHOD_POST,

--- a/Gateway/Request/PaymentRequest.php
+++ b/Gateway/Request/PaymentRequest.php
@@ -11,6 +11,7 @@ use Magento\Payment\Gateway\Helper\SubjectReader;
 use Magento\Framework\UrlInterface;
 use Magento\Payment\Helper\Formatter;
 use Ngenius\NgeniusCommon\Formatter\ValueFormatter;
+use Ngenius\NgeniusCommon\NgeniusUtilities;
 
 class PaymentRequest implements BuilderInterface
 {
@@ -44,11 +45,11 @@ class PaymentRequest implements BuilderInterface
     /**
      * PaymentRequest constructor.
      *
-     * @param Config                $config
-     * @param TokenRequest          $tokenRequest
+     * @param Config $config
+     * @param TokenRequest $tokenRequest
      * @param StoreManagerInterface $storeManager
-     * @param Session               $checkoutSession
-     * @param UrlInterface          $urlBuilder
+     * @param Session $checkoutSession
+     * @param UrlInterface $urlBuilder
      */
     public function __construct(
         Config $config,
@@ -57,33 +58,34 @@ class PaymentRequest implements BuilderInterface
         Session $checkoutSession,
         UrlInterface $urlBuilder
     ) {
-        $this->config = $config;
-        $this->tokenRequest = $tokenRequest;
-        $this->storeManager = $storeManager;
+        $this->config          = $config;
+        $this->tokenRequest    = $tokenRequest;
+        $this->storeManager    = $storeManager;
         $this->checkoutSession = $checkoutSession;
-        $this->urlBuilder = $urlBuilder;
+        $this->urlBuilder      = $urlBuilder;
     }
 
     /**
      * Builds ENV request
      *
-     * @param  array $buildSubject
-     * @throws CouldNotSaveException
+     * @param array $buildSubject
+     *
      * @return array
+     * @throws CouldNotSaveException
      */
     public function build(array $buildSubject)
     {
         $paymentDO = SubjectReader::readPayment($buildSubject);
         $paymentDO->getPayment()->setIsTransactionPending(true);
-        $order = $paymentDO->getOrder();
+        $order   = $paymentDO->getOrder();
         $storeId = $order->getStoreId();
-        $amount = $this->formatPrice(SubjectReader::readAmount($buildSubject)) * 100;
+        $amount  = $this->formatPrice(SubjectReader::readAmount($buildSubject)) * 100;
 
         if ($this->config->isComplete($storeId)) {
             $this->setTableData($order);
 
-            return[
-                'token' => $this->tokenRequest->getAccessToken($storeId),
+            return [
+                'token'   => $this->tokenRequest->getAccessToken($storeId),
                 'request' => $this->getBuildArray($order, $storeId, $amount)
             ];
         } else {
@@ -94,7 +96,8 @@ class PaymentRequest implements BuilderInterface
     /**
      * Set Table Data
      *
-     * @param  object $order
+     * @param object $order
+     *
      * @return null
      */
     protected function setTableData($order)
@@ -102,7 +105,7 @@ class PaymentRequest implements BuilderInterface
         $data = [
             'order_id' => $order->getOrderIncrementId(),
             'currency' => $order->getCurrencyCode(),
-            'amount' => $order->getGrandTotalAmount()
+            'amount'   => $order->getGrandTotalAmount()
         ];
         $this->checkoutSession->setTableData($data);
     }
@@ -114,11 +117,14 @@ class PaymentRequest implements BuilderInterface
      * @param int $storeId
      * @param float $amount
      * @param string $action
+     *
      * @return array
      */
     public function getBuildArray($order, $storeId, $amount, $action): array
     {
         $currencyCode = $order->getOrderCurrencyCode();
+        $countryCode  = $order->getBillingAddress()->getCountryId();
+        $utilities    = new NgeniusUtilities();
 
         ValueFormatter::formatCurrencyAmount($currencyCode, $amount);
 
@@ -138,12 +144,23 @@ class PaymentRequest implements BuilderInterface
                 'merchantOrderReference' => $order->getRealOrderId(),
                 'emailAddress'           => $order->getBillingAddress()->getEmail(),
                 'billingAddress'         => [
-                    'firstName' => $order->getBillingAddress()->getFirstName(),
-                    'lastName'  => $order->getBillingAddress()->getLastName(),
+                    'firstName'   => $order->getBillingAddress()->getFirstName(),
+                    'lastName'    => $order->getBillingAddress()->getLastName(),
+                    'address1'    => $order->getBillingAddress()->getStreetLine(1),
+                    'address2'    => $order->getBillingAddress()->getStreetLine(2),
+                    'city'        => $order->getBillingAddress()->getCity(),
+                    'stateCode'   => $order->getBillingAddress()->getRegion(),
+                    'postalCode'  => $order->getBillingAddress()->getPostcode(),
+                    'countryCode' => $countryCode,
+
                 ],
-                'merchantDefinedData' => [
-                    'pluginName' => 'magento-2',
-                    'pluginVersion' => '1.1.3'
+                'phoneNumber'            => [
+                    'countryCode' => $utilities->getCountryTelephonePrefix($countryCode),
+                    'subscriber'  => $order->getBillingAddress()->getTelephone(),
+                ],
+                'merchantDefinedData'    => [
+                    'pluginName'    => 'magento-2',
+                    'pluginVersion' => '1.1.4'
                 ]
             ],
             'method' => \Laminas\Http\Request::METHOD_POST,

--- a/Gateway/Request/RefundRequest.php
+++ b/Gateway/Request/RefundRequest.php
@@ -108,7 +108,7 @@ class RefundRequest implements BuilderInterface
         $token = $this->tokenRequest->getAccessToken($storeId);
         list($refund_url, $method, $error) = $this->getRefundUrl($token, $orderReference);
 
-        $amount = $this->formatPrice(SubjectReader::readAmount($buildSubject)) * 100;
+        $amount       = $this->formatPrice(SubjectReader::readAmount($buildSubject)) * 100;
         $currencyCode = $order_details->getOrderCurrencyCode();
 
         ValueFormatter::formatCurrencyAmount($currencyCode, $amount);
@@ -122,13 +122,13 @@ class RefundRequest implements BuilderInterface
                 'token'   => $token,
                 'request' => [
                     'data'   => [
-                        'amount' => [
+                        'amount'              => [
                             'currencyCode' => $currencyCode,
                             'value'        => $amount
                         ],
                         'merchantDefinedData' => [
-                            'pluginName' => 'magento-2',
-                            'pluginVersion' => '1.1.3'
+                            'pluginName'    => 'magento-2',
+                            'pluginVersion' => '1.1.4'
                         ]
                     ],
                     'method' => $method,
@@ -177,6 +177,7 @@ class RefundRequest implements BuilderInterface
      *
      * @param string $token
      * @param string $order_ref
+     *
      * @return mixed
      * @throws NoSuchEntityException
      */
@@ -186,7 +187,7 @@ class RefundRequest implements BuilderInterface
     ) {
         $url = $this->config->getFetchRequestURL($order_ref);
 
-        $storeId = $this->storeManager->getStore()->getId();
+        $storeId             = $this->storeManager->getStore()->getId();
         $ngeniusHttpTransfer = new NgeniusHTTPTransfer($url, $this->config->getHttpVersion($storeId));
         $ngeniusHttpTransfer->setMethod('GET');
         $ngeniusHttpTransfer->setPaymentHeaders($token);

--- a/Gateway/Request/VoidRequest.php
+++ b/Gateway/Request/VoidRequest.php
@@ -32,8 +32,8 @@ class VoidRequest implements BuilderInterface
     /**
      * VoidRequest constructor.
      *
-     * @param Config                $config
-     * @param TokenRequest          $tokenRequest
+     * @param Config $config
+     * @param TokenRequest $tokenRequest
      * @param StoreManagerInterface $storeManager
      */
     public function __construct(
@@ -64,7 +64,7 @@ class VoidRequest implements BuilderInterface
         $paymentResult = json_decode($payment->getAdditionalInformation('paymentResult'));
 
         $transactionId = $paymentResult->reference;
-        $orderId = $paymentResult->orderReference;
+        $orderId       = $paymentResult->orderReference;
 
         if (!$transactionId) {
             throw new LocalizedException(__('No authorization transaction to proceed.'));

--- a/Gateway/Validator/CaptureValidator.php
+++ b/Gateway/Validator/CaptureValidator.php
@@ -31,8 +31,8 @@ class CaptureValidator extends AbstractValidator
      * CaptureValidator constructor.
      *
      * @param ResultInterfaceFactory $resultFactory
-     * @param BuilderInterface       $transactionBuilder
-     * @param OrderFactory           $orderFactory
+     * @param BuilderInterface $transactionBuilder
+     * @param OrderFactory $orderFactory
      */
     public function __construct(
         ResultInterfaceFactory $resultFactory,
@@ -72,15 +72,15 @@ class CaptureValidator extends AbstractValidator
             ];
             $payment->setTransactionId($response['result']['payment_id']);
             $transaction = $this->transactionBuilder->setPayment($payment)
-                ->setOrder($order)
-                ->setTransactionId($response['result']['payment_id'])
-                ->setAdditionalInformation(
-                    [Transaction::RAW_DETAILS => (array)$paymentData]
-                )
-                ->setFailSafe(true)
-                ->build(
-                    Transaction::TYPE_CAPTURE
-                );
+                                                    ->setOrder($order)
+                                                    ->setTransactionId($response['result']['payment_id'])
+                                                    ->setAdditionalInformation(
+                                                        [Transaction::RAW_DETAILS => (array)$paymentData]
+                                                    )
+                                                    ->setFailSafe(true)
+                                                    ->build(
+                                                        Transaction::TYPE_CAPTURE
+                                                    );
             $payment->addTransactionCommentsToOrder($transaction, null);
             $payment->save();
             $order->addStatusToHistory(

--- a/Gateway/Validator/RefundValidator.php
+++ b/Gateway/Validator/RefundValidator.php
@@ -31,8 +31,8 @@ class RefundValidator extends AbstractValidator
      * RefundValidator constructor.
      *
      * @param ResultInterfaceFactory $resultFactory
-     * @param BuilderInterface       $transactionBuilder
-     * @param OrderFactory           $orderFactory
+     * @param BuilderInterface $transactionBuilder
+     * @param OrderFactory $orderFactory
      */
     public function __construct(
         ResultInterfaceFactory $resultFactory,
@@ -74,15 +74,15 @@ class RefundValidator extends AbstractValidator
             ];
             $payment->setTransactionId($response['result']['payment_id']);
             $transaction = $this->transactionBuilder->setPayment($payment)
-                ->setOrder($order)
-                ->setTransactionId($response['result']['payment_id'])
-                ->setAdditionalInformation(
-                    [Transaction::RAW_DETAILS => (array)$paymentData]
-                )
-                ->setFailSafe(true)
-                ->build(
-                    Transaction::TYPE_CAPTURE
-                );
+                                                    ->setOrder($order)
+                                                    ->setTransactionId($response['result']['payment_id'])
+                                                    ->setAdditionalInformation(
+                                                        [Transaction::RAW_DETAILS => (array)$paymentData]
+                                                    )
+                                                    ->setFailSafe(true)
+                                                    ->build(
+                                                        Transaction::TYPE_CAPTURE
+                                                    );
             $payment->addTransactionCommentsToOrder($transaction, null);
             $payment->save();
             $order->addStatusToHistory(

--- a/Gateway/Validator/ResponseValidator.php
+++ b/Gateway/Validator/ResponseValidator.php
@@ -16,12 +16,12 @@ class ResponseValidator extends AbstractValidator
     /**
      * Performs validation of result code
      *
-     * @param  array $validationSubject
+     * @param array $validationSubject
+     *
      * @return ResultInterface
      */
     public function validate(array $validationSubject)
     {
-
         $response = SubjectReader::readResponse($validationSubject);
 
         if (!isset($response['payment_url']) && filter_var($response['payment_url'], FILTER_VALIDATE_URL) === false) {

--- a/Gateway/Validator/VoidValidator.php
+++ b/Gateway/Validator/VoidValidator.php
@@ -30,8 +30,8 @@ class VoidValidator extends AbstractValidator
      * VoidValidator constructor.
      *
      * @param ResultInterfaceFactory $resultFactory
-     * @param BuilderInterface       $transactionBuilder
-     * @param OrderFactory           $orderFactory
+     * @param BuilderInterface $transactionBuilder
+     * @param OrderFactory $orderFactory
      */
     public function __construct(
         ResultInterfaceFactory $resultFactory,
@@ -39,27 +39,28 @@ class VoidValidator extends AbstractValidator
         OrderFactory $orderFactory
     ) {
         $this->transactionBuilder = $transactionBuilder;
-        $this->orderFactory = $orderFactory;
+        $this->orderFactory       = $orderFactory;
         parent::__construct($resultFactory);
     }
 
     /**
      * Performs validation of result code
      *
-     * @param  array $validationSubject
+     * @param array $validationSubject
+     *
      * @return ResultInterface|null
      */
     public function validate(array $validationSubject)
     {
         try {
-            if (! empty($validationSubject)) {
+            if (!empty($validationSubject)) {
                 $response     = SubjectReader::readResponse($validationSubject);
                 $paymentDO    = SubjectReader::readPayment($validationSubject);
                 $orderAdapter = $paymentDO->getOrder();
 
                 $order = $this->orderFactory->create()->load($orderAdapter->getId());
 
-                if (! isset($response['result']) && ! is_array($response['result'])) {
+                if (!isset($response['result']) && !is_array($response['result'])) {
                     return $this->createResult(
                         false,
                         [__('Invalid void transaction.')]

--- a/Model/Config/OrderStatus.php
+++ b/Model/Config/OrderStatus.php
@@ -19,7 +19,6 @@ class OrderStatus implements ArrayInterface
      */
     public function toOptionArray()
     {
-
         $status = DataPatch::getStatuses();
 
         return [['value' => $status[0]['status'], 'label' => __($status[0]['label'])]];

--- a/Model/Email/OrderSender.php
+++ b/Model/Email/OrderSender.php
@@ -65,6 +65,7 @@ class OrderSender extends \Magento\Sales\Model\Order\Email\Sender\OrderSender
         $this->globalConfig  = $globalConfig;
         $this->config        = $config;
     }
+
     /**
      * Sends order email to the customer.
      *
@@ -77,7 +78,7 @@ class OrderSender extends \Magento\Sales\Model\Order\Email\Sender\OrderSender
      * corresponding cron job.
      *
      * @param Order $order
-     * @param bool  $forceSyncMode
+     * @param bool $forceSyncMode
      *
      * @return bool
      * @throws \Magento\Framework\Exception\LocalizedException
@@ -86,7 +87,7 @@ class OrderSender extends \Magento\Sales\Model\Order\Email\Sender\OrderSender
     {
         $paymentCode = $order->getPayment()->getMethodInstance()->getCode();
 
-        $storeId = $order->getStoreId();
+        $storeId      = $order->getStoreId();
         $emailOnOrder = $this->config->getEmailSend($storeId);
 
         $sendOrder = false;
@@ -110,6 +111,7 @@ class OrderSender extends \Magento\Sales\Model\Order\Email\Sender\OrderSender
                 if ($this->checkAndSend($order)) {
                     $order->setEmailSent(true);
                     $this->orderResource->saveAttribute($order, ['send_email', 'email_sent']);
+
                     return true;
                 }
             } else {
@@ -118,6 +120,7 @@ class OrderSender extends \Magento\Sales\Model\Order\Email\Sender\OrderSender
             }
 
             $this->orderResource->saveAttribute($order, 'send_email');
+
             return false;
         }
     }

--- a/Model/ResourceModel/Core.php
+++ b/Model/ResourceModel/Core.php
@@ -20,6 +20,6 @@ class Core extends AbstractDb
      */
     protected function _construct()
     {
-        $this->_init('ngenius_networkinternational', 'nid');
+        $this->_init('ngenius_networkinternational_sales_order', 'nid');
     }
 }

--- a/Observer/OrderAuthCaptured.php
+++ b/Observer/OrderAuthCaptured.php
@@ -26,11 +26,12 @@ class OrderAuthCaptured implements ObserverInterface
      * Order capture observer to set custom order statuses accordingly
      *
      * @param Observer $observer
+     *
      * @return void
      */
     public function execute(Observer $observer)
     {
-        $order      = $observer->getInvoice()->getOrder();
+        $order = $observer->getInvoice()->getOrder();
 
         $paymentResult = $order->getPayment()->getAdditionalInformation("paymentResult") ?? null;
 
@@ -38,12 +39,12 @@ class OrderAuthCaptured implements ObserverInterface
             return;
         }
 
-        $orderRef       = json_decode($paymentResult)->orderReference;
-        $collection    = $this->coreFactory->create()->getCollection()->addFieldToFilter(
+        $orderRef   = json_decode($paymentResult)->orderReference;
+        $collection = $this->coreFactory->create()->getCollection()->addFieldToFilter(
             'reference',
             $orderRef
         );
-        $orderItem     = $collection->getFirstItem();
+        $orderItem  = $collection->getFirstItem();
 
         if ($orderItem->getData()["action"] !== "AUTH"
             || (int)($orderItem->getData()["captured_amt"]) === 0

--- a/Observer/OrderCancelAfter.php
+++ b/Observer/OrderCancelAfter.php
@@ -31,9 +31,9 @@ class OrderCancelAfter implements ObserverInterface
     protected $storeManager;
 
     /**
-     * @param Config                                                 $config
+     * @param Config $config
      * @param \Magento\Sales\Model\Order\Payment\Transaction\Builder $transactionBuilder
-     * @param StoreManagerInterface                                  $storeManager
+     * @param StoreManagerInterface $storeManager
      */
 
     public function __construct(Config $config, Builder $transactionBuilder, StoreManagerInterface $storeManager)
@@ -53,6 +53,12 @@ class OrderCancelAfter implements ObserverInterface
      */
     public function execute(Observer $observer): void
     {
+        $order = $observer->getOrder();
+
+        if ($order->getPayment()->getMethodInstance()->getCode() !== Config::CODE) {
+            return;
+        }
+
         $storeId = $this->storeManager->getStore()->getId();
 
         if ($this->config->getCustomFailedOrderStatus($storeId) != null) {

--- a/Observer/OrderShipped.php
+++ b/Observer/OrderShipped.php
@@ -28,12 +28,13 @@ class OrderShipped implements ObserverInterface
      * Forces order into processing for ship action
      *
      * @param Observer $observer
+     *
      * @return void
      */
     public function execute(Observer $observer)
     {
         $shipment = $observer->getEvent()->getShipment();
-        $order = $shipment->getOrder();
+        $order    = $shipment->getOrder();
         if ($order->getPayment()->getMethodInstance()->getCode() === Config::CODE
             && $order->getState() !== Order::STATE_PROCESSING
         ) {

--- a/Observer/PaymentVoid.php
+++ b/Observer/PaymentVoid.php
@@ -23,7 +23,7 @@ class PaymentVoid implements ObserverInterface
     private CoreFactory $coreFactory;
 
     /**
-     * @param \Psr\Log\LoggerInterface                        $logger
+     * @param \Psr\Log\LoggerInterface $logger
      * @param \NetworkInternational\NGenius\Model\CoreFactory $coreFactory
      */
     public function __construct(LoggerInterface $logger, CoreFactory $coreFactory)
@@ -44,8 +44,8 @@ class PaymentVoid implements ObserverInterface
 
         $ptid       = $payment->getParentTransactionId();
         $collection = $this->coreFactory->create()
-            ->getCollection()
-            ->addFieldToFilter('payment_id', $ptid);
+                                        ->getCollection()
+                                        ->addFieldToFilter('payment_id', $ptid);
 
         $orderItem = $collection->getFirstItem();
         $reversed  = $orderItem->getData('state');

--- a/Observer/ProductQty.php
+++ b/Observer/ProductQty.php
@@ -19,7 +19,8 @@ class ProductQty
     /**
      * Prepare array with information about used product qty and product stock item
      *
-     * @param  array $relatedItems
+     * @param array $relatedItems
+     *
      * @return array
      */
     public function getProductQty($relatedItems)
@@ -39,6 +40,7 @@ class ProductQty
                 $this->_addItemToQtyArray($item, $items);
             }
         }
+
         return $items;
     }
 
@@ -47,6 +49,7 @@ class ProductQty
      *
      * @param QuoteItem $quoteItem
      * @param array $items
+     *
      * @return void
      */
     protected function _addItemToQtyArray(QuoteItem $quoteItem, &$items)

--- a/Observer/ProductSaveAfter.php
+++ b/Observer/ProductSaveAfter.php
@@ -81,8 +81,8 @@ class ProductSaveAfter implements ObserverInterface
     {
         $lastRealOrder = $this->checkoutSession->getLastRealOrder();
         if ($lastRealOrder->getPayment() && $lastRealOrder->getData('state') === 'new' && ($lastRealOrder->getData(
-            'status'
-        ) === "payment_review")
+                    'status'
+                ) === "payment_review")
         ) {
             $this->checkoutSession->restoreQuote();
 

--- a/Observer/PurchaseRefund.php
+++ b/Observer/PurchaseRefund.php
@@ -121,10 +121,10 @@ class PurchaseRefund implements ObserverInterface
         Config $config,
         StoreManagerInterface $storeManager
     ) {
-        $this->logger        = $logger;
-        $this->coreFactory   = $coreFactory;
-        $this->config        = $config;
-        $this->storeManager  = $storeManager;
+        $this->logger       = $logger;
+        $this->coreFactory  = $coreFactory;
+        $this->config       = $config;
+        $this->storeManager = $storeManager;
     }
 
     /**
@@ -144,14 +144,14 @@ class PurchaseRefund implements ObserverInterface
 
         $parentTransactionId = $payment->getParentTransactionId() !== null ? $payment->getParentTransactionId() : '';
 
-        $ptid = str_replace("-capture", "", $parentTransactionId);
+        $ptid       = str_replace("-capture", "", $parentTransactionId);
         $collection = $this->coreFactory->create()
-            ->getCollection()
-            ->addFieldToFilter('payment_id', $ptid);
+                                        ->getCollection()
+                                        ->addFieldToFilter('payment_id', $ptid);
 
         $orderItem  = $collection->getFirstItem();
         $itemStatus = $orderItem->getData('status') ?? "";
-        $itemState = $orderItem->getData('state') ?? "";
+        $itemState  = $orderItem->getData('state') ?? "";
 
         $storeId = $this->storeManager->getStore()->getId();
 

--- a/Observer/Standard.php
+++ b/Observer/Standard.php
@@ -25,7 +25,7 @@ class Standard implements ObserverInterface
     /**
      * Standard constructor.
      *
-     * @param Session                                     $checkoutSession
+     * @param Session $checkoutSession
      * @param \Magento\Framework\Message\ManagerInterface $messageManager
      */
     public function __construct(
@@ -33,7 +33,7 @@ class Standard implements ObserverInterface
         \Magento\Framework\Message\ManagerInterface $messageManager
     ) {
         $this->checkoutSession = $checkoutSession;
-        $this->messageManager = $messageManager;
+        $this->messageManager  = $messageManager;
     }
 
     /**

--- a/README.md
+++ b/README.md
@@ -4,17 +4,21 @@
 
 ## Installation
 
-For more detailed instructions on setting up the N-Genius Magento plugin, please refer to our [documentation.](https://docs.ngenius-payments.com/docs/magento-245)
+For more detailed instructions on setting up the N-Genius Magento plugin, please refer to
+our [documentation.](https://docs.ngenius-payments.com/docs/magento-245)
 
 #### Install using Composer (recommended)
 
-- From the Magento root directory, install the N-Genius module using ```composer require networkinternational/ngenius```.
+- From the Magento root directory, install the N-Genius module
+  using ```composer require networkinternational/ngenius```.
 
 #### Install using FTP/SFTP
 
 - Download ***ngenius-magento-plugin-master.zip*** and unzip it to a directory on your local machine.
-- Use an FTP tool (such as *FileZilla*) to upload the contents of ```ngenius-magento-plugin-master``` directory to the ```app\code\NetworkInternational\NGenius\```directory of your Magento installation.
-- From the Magento root directory, install N-Genius dependencies using ```composer require ngenius/ngenius-common:v1.0.6```.
+- Use an FTP tool (such as *FileZilla*) to upload the contents of ```ngenius-magento-plugin-master``` directory to
+  the ```app\code\NetworkInternational\NGenius\```directory of your Magento installation.
+- From the Magento root directory, install N-Genius dependencies
+  using ```composer require ngenius/ngenius-common:v1.0.8```.
 
 ### Magento Build Steps
 
@@ -26,4 +30,5 @@ For more detailed instructions on setting up the N-Genius Magento plugin, please
 
 ## Download
 
-You can download the latest version of the plugin from our [Github releases page](https://github.com/network-international/ngenius-magento-plugin/releases)
+You can download the latest version of the plugin from
+our [Github releases page](https://github.com/network-international/ngenius-magento-plugin/releases)

--- a/Setup/Patch/Data/DataPatch.php
+++ b/Setup/Patch/Data/DataPatch.php
@@ -38,8 +38,8 @@ class DataPatch implements DataPatchInterface
 
         $checkExistingStatus1 = $this->moduleDataSetup->getConnection()->fetchOne(
             $this->moduleDataSetup->getConnection()->select()
-                ->from($table)
-                ->where('status = ?', 'ngenius_pending')
+                                  ->from($table)
+                                  ->where('status = ?', 'ngenius_pending')
         );
 
         if (!$checkExistingStatus1) {
@@ -48,8 +48,8 @@ class DataPatch implements DataPatchInterface
 
         $checkExistingStatus2 = $this->moduleDataSetup->getConnection()->fetchOne(
             $this->moduleDataSetup->getConnection()->select()
-                ->from($table)
-                ->where('status = ?', 'ngenius_declined')
+                                  ->from($table)
+                                  ->where('status = ?', 'ngenius_declined')
         );
 
         if (!$checkExistingStatus2) {
@@ -59,7 +59,7 @@ class DataPatch implements DataPatchInterface
                     $table1,
                     [
                         'status' => 'ngenius_declined',
-                        'label' => 'N-Genius Declined',
+                        'label'  => 'N-Genius Declined',
                     ]
                 );
             }
@@ -69,9 +69,9 @@ class DataPatch implements DataPatchInterface
                 $this->moduleDataSetup->getConnection()->insert(
                     $table2,
                     [
-                        'status' => 'ngenius_declined',
-                        'state' => 'ngenius_state',
-                        'is_default' => 0,
+                        'status'           => 'ngenius_declined',
+                        'state'            => 'ngenius_state',
+                        'is_default'       => 0,
                         'visible_on_front' => 1,
                     ]
                 );
@@ -90,11 +90,11 @@ class DataPatch implements DataPatchInterface
     {
         // Add code from the DataPatch class
         $this->moduleDataSetup->getConnection()
-            ->insertArray(
-                $this->moduleDataSetup->getTable('sales_order_status'),
-                ['status', 'label'],
-                $this->getStatuses()
-            );
+                              ->insertArray(
+                                  $this->moduleDataSetup->getTable('sales_order_status'),
+                                  ['status', 'label'],
+                                  $this->getStatuses()
+                              );
 
         $state[] = ['ngenius_pending', self::STATE, '1', '1'];
         $state[] = ['ngenius_processing', self::STATE, '0', '1'];
@@ -109,11 +109,11 @@ class DataPatch implements DataPatchInterface
         $state[] = ['ngenius_declined', self::STATE, '0', '1'];
 
         $this->moduleDataSetup->getConnection()
-            ->insertArray(
-                $this->moduleDataSetup->getTable('sales_order_status_state'),
-                ['status', 'state', 'is_default', 'visible_on_front'],
-                $state
-            );
+                              ->insertArray(
+                                  $this->moduleDataSetup->getTable('sales_order_status_state'),
+                                  ['status', 'state', 'is_default', 'visible_on_front'],
+                                  $state
+                              );
     }
 
     /**

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,13 @@
 Date                Version     Description
 =========================================================================
 
+2024-03-18: v1.1.4 : Add VISA additional mandatory fields to the Order API Request Body.
+                     Don't allow OrderCancelAfter Observer to trigger for other payment methods.
+                     Don't allow Cron to process orders created by other payment methods. 
+                     Change the cron table from ngenius_networkinternational to ngenius_networkinternational_sales_order to avoid the processing of historic orders.
+                     Fix Cron order processing of abandoned APM methods in a state of AWAIT_3DS.
+                     Improve payment action support for China Union Pay.
+
 2023-11-28: v1.1.3 : Cancel abandoned orders after one hour using the cron.
                      Add the ability to debug cron job order processing.
                      Update to N-Genius Common Class 1.0.6.

--- a/composer.json
+++ b/composer.json
@@ -2,16 +2,18 @@
   "name": "networkinternational/ngenius",
   "description": "Network International N-Genius Payment Gateway for Magento 2",
   "type": "magento2-module",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "minimum-stability": "stable",
   "license": "GPL-3.0",
-  "authors": [{
-    "name": "App Inlet (Pty) Ltd",
-    "email": "info@appinlet.com"
-  }],
+  "authors": [
+    {
+      "name": "App Inlet (Pty) Ltd",
+      "email": "info@appinlet.com"
+    }
+  ],
   "require": {
     "php": "^8.1",
-    "ngenius/ngenius-common": "v1.0.6"
+    "ngenius/ngenius-common": "v1.0.8"
   },
   "autoload": {
     "files": [

--- a/etc/adminhtml/events.xml
+++ b/etc/adminhtml/events.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
     <event name="sales_order_place_after">
-        <observer name="ngenius_order_place_after" instance="NetworkInternational\NGenius\Observer\Standard" />
+        <observer name="ngenius_order_place_after" instance="NetworkInternational\NGenius\Observer\Standard"/>
     </event>
 </config>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -1,44 +1,54 @@
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
     <system>
         <section id="payment">
-            <group id="ngeniusonline" translate="label" type="text" sortOrder="50" showInDefault="1" showInWebsite="1" showInStore="1">
+            <group id="ngeniusonline" translate="label" type="text" sortOrder="50" showInDefault="1" showInWebsite="1"
+                   showInStore="1">
                 <label>N-Genius Online</label>
-                <field id="active" translate="label" type="select" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="0">
+                <field id="active" translate="label" type="select" sortOrder="1" showInDefault="1" showInWebsite="1"
+                       showInStore="0">
                     <label>Enabled</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <config_path>payment/ngeniusonline/active</config_path>
                 </field>
-                <field id="title" translate="label" type="text" sortOrder="2" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="title" translate="label" type="text" sortOrder="2" showInDefault="1" showInWebsite="1"
+                       showInStore="1">
                     <label>Title</label>
                     <config_path>payment/ngeniusonline/title</config_path>
                     <validate>required-entry</validate>
                 </field>
-                <field id="environment" translate="label" type="select" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="0" >
+                <field id="environment" translate="label" type="select" sortOrder="3" showInDefault="1"
+                       showInWebsite="1" showInStore="0">
                     <label>Environment</label>
                     <source_model>NetworkInternational\NGenius\Model\Config\Environment</source_model>
                     <config_path>payment/ngeniusonline/environment</config_path>
                 </field>
-                <field id="uat_api_url" translate="label" type="text" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="uat_api_url" translate="label" type="text" sortOrder="4" showInDefault="1" showInWebsite="1"
+                       showInStore="1">
                     <label>Sandbox API URL</label>
                     <validate>required-entry</validate>
                     <config_path>payment/ngeniusonline/uat_api_url</config_path>
                 </field>
-                <field id="live_api_url" translate="label" type="text" sortOrder="5" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="live_api_url" translate="label" type="text" sortOrder="5" showInDefault="1" showInWebsite="1"
+                       showInStore="1">
                     <label>Live API URL</label>
                     <validate>required-entry</validate>
                     <config_path>payment/ngeniusonline/live_api_url</config_path>
                 </field>
-                <field id="payment_action" translate="label" type="select" sortOrder="5.5" showInDefault="1" showInWebsite="1" showInStore="1" >
+                <field id="payment_action" translate="label" type="select" sortOrder="5.5" showInDefault="1"
+                       showInWebsite="1" showInStore="1">
                     <label>Magento Payment Action</label>
                     <source_model>NetworkInternational\NGenius\Model\Config\PaymentAction</source_model>
                     <config_path>payment/ngeniusonline/payment_action</config_path>
                 </field>
-                <field id="ngenius_payment_action" translate="label" type="select" sortOrder="6" showInDefault="1" showInWebsite="1" showInStore="0" >
-                    <label>NGenius Payment Action</label>
+                <field id="ngenius_payment_action" translate="label" type="select" sortOrder="6" showInDefault="1"
+                       showInWebsite="1" showInStore="0">
+                    <label>N-Genius Payment Action</label>
                     <source_model>NetworkInternational\NGenius\Model\Config\NgeniusPaymentAction</source_model>
                     <config_path>payment/ngeniusonline/ngenius_payment_action</config_path>
                 </field>
-                <field id="ngenius_initial_order_status" translate="label" type="select" sortOrder="7" showInDefault="1" showInWebsite="1" showInStore="1" >
+                <field id="ngenius_initial_order_status" translate="label" type="select" sortOrder="7" showInDefault="1"
+                       showInWebsite="1" showInStore="1">
                     <label>Status of new order</label>
                     <config_path>payment/ngeniusonline/ngenius_initial_order_status</config_path>
                     <source_model>Magento\Sales\Model\ResourceModel\Order\Status\Collection</source_model>
@@ -71,13 +81,16 @@
                        showInWebsite="1" showInStore="0">
                     <label>N-Genius Refund Statuses</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                    <comment>Select "Yes" to set custom N-Genius refund order statuses after a successful refund.</comment>
+                    <comment>Select "Yes" to set custom N-Genius refund order statuses after a successful refund.
+                    </comment>
                 </field>
                 <field id="order_email" translate="label" type="select" sortOrder="9.4" showInDefault="1"
                        showInWebsite="1" showInStore="0">
                     <label>Send Email on Order Creation</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                    <comment>Select "Yes" to send the order email when landing on the payment page. "No" will only send the order email when payment is successful.</comment>
+                    <comment>Select "Yes" to send the order email when landing on the payment page. "No" will only send
+                        the order email when payment is successful.
+                    </comment>
                 </field>
                 <field id="invoice_email" translate="label" type="select" sortOrder="9.5" showInDefault="1"
                        showInWebsite="1" showInStore="0">
@@ -85,7 +98,8 @@
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <comment>Select "Yes" to send the invoice email when payment is successful.</comment>
                 </field>
-                <field id="outlet_ref" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="0">
+                <field id="outlet_ref" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1"
+                       showInStore="0">
                     <label>Outlet Reference ID</label>
                     <config_path>payment/ngeniusonline/outlet_ref</config_path>
                     <validate>required-entry</validate>
@@ -93,14 +107,16 @@
                         <field id="active">1</field>
                     </depends>
                 </field>
-                <field id="outlet_ref_2" translate="label" type="text" sortOrder="11" showInDefault="1" showInWebsite="1" showInStore="0">
+                <field id="outlet_ref_2" translate="label" type="text" sortOrder="11" showInDefault="1"
+                       showInWebsite="1" showInStore="0">
                     <label>Outlet Reference 2 ID (Optional)</label>
                     <config_path>payment/ngeniusonline/outlet_ref_2</config_path>
                     <depends>
                         <field id="active">1</field>
                     </depends>
                 </field>
-                <field id="outlet_ref_2_currencies" translate="label" type="multiselect" sortOrder="12" showInDefault="1" showInWebsite="1" showInStore="0">
+                <field id="outlet_ref_2_currencies" translate="label" type="multiselect" sortOrder="12"
+                       showInDefault="1" showInWebsite="1" showInStore="0">
                     <label>Outlet Reference 2 Currencies (Optional)</label>
                     <config_path>payment/ngeniusonline/outlet_ref_2_currencies</config_path>
                     <source_model>NetworkInternational\NGenius\Model\Config\OutletCurrencies</source_model>
@@ -108,7 +124,8 @@
                         <field id="active">1</field>
                     </depends>
                 </field>
-                <field id="api_key" translate="label" type="text" sortOrder="13" showInDefault="1" showInWebsite="1" showInStore="0">
+                <field id="api_key" translate="label" type="text" sortOrder="13" showInDefault="1" showInWebsite="1"
+                       showInStore="0">
                     <label>API Key</label>
                     <config_path>payment/ngeniusonline/api_key</config_path>
                     <validate>required-entry</validate>
@@ -116,17 +133,20 @@
                         <field id="active">1</field>
                     </depends>
                 </field>
-                <field id="http_version" translate="label" type="select" sortOrder="14" showInDefault="1" showInWebsite="1" showInStore="0">
+                <field id="http_version" translate="label" type="select" sortOrder="14" showInDefault="1"
+                       showInWebsite="1" showInStore="0">
                     <label>HTTP Version</label>
                     <source_model>NetworkInternational\NGenius\Model\Config\HttpVersion</source_model>
                     <config_path>payment/ngeniusonline/http_version</config_path>
                 </field>
-                <field id="debug" translate="label" type="select" sortOrder="15" showInDefault="1" showInWebsite="1" showInStore="0">
+                <field id="debug" translate="label" type="select" sortOrder="15" showInDefault="1" showInWebsite="1"
+                       showInStore="0">
                     <label>Debug</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <config_path>payment/ngeniusonline/debug</config_path>
                 </field>
-                <field id="debug_cron" translate="label" type="select" sortOrder="15" showInDefault="1" showInWebsite="1" showInStore="0">
+                <field id="debug_cron" translate="label" type="select" sortOrder="15" showInDefault="1"
+                       showInWebsite="1" showInStore="0">
                     <label>Debug Cron</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <config_path>payment/ngeniusonline/debug_cron</config_path>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
     <default>
         <payment>
             <ngeniusonline>
@@ -42,8 +43,10 @@
                 <order_endpoint><![CDATA[/transactions/outlets/%s/orders]]></order_endpoint>
                 <fetch_endpoint><![CDATA[/transactions/outlets/%s/orders/%s]]></fetch_endpoint>
                 <capture_endpoint><![CDATA[/transactions/outlets/%s/orders/%s/payments/%s/captures]]></capture_endpoint>
-                <void_auth_endpoint><![CDATA[/transactions/outlets/%s/orders/%s/payments/%s/cancel]]></void_auth_endpoint>
-                <refund_endpoint><![CDATA[/transactions/outlets/%s/orders/%s/payments/%s/captures/%s/refund]]></refund_endpoint>
+                <void_auth_endpoint>
+                    <![CDATA[/transactions/outlets/%s/orders/%s/payments/%s/cancel]]></void_auth_endpoint>
+                <refund_endpoint>
+                    <![CDATA[/transactions/outlets/%s/orders/%s/payments/%s/captures/%s/refund]]></refund_endpoint>
             </ngeniusonline>
         </payment>
     </default>

--- a/etc/cron_groups.xml
+++ b/etc/cron_groups.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/cron_groups.xsd">
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/cron_groups.xsd">
     <group id="ngenius_payment_gateway">
         <schedule_generate_every>5</schedule_generate_every>
         <schedule_ahead_for>4</schedule_ahead_for>

--- a/etc/crontab.xml
+++ b/etc/crontab.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" ?>
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/crontab.xsd">
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/crontab.xsd">
     <group id="ngenius_payment_gateway">
         <job instance="NetworkInternational\NGenius\Cron\UpdateOrder" method="execute" name="ngenius_order_update">
             <schedule>*/5 * * * *</schedule>

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -1,17 +1,22 @@
-<schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/schema.xsd">
-    <table name="ngenius_networkinternational" resource="default" engine="innodb" comment="N-Genius order table">
+<schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/schema.xsd">
+    <table name="ngenius_networkinternational_sales_order" resource="default" engine="innodb"
+           comment="N-Genius order table">
         <column xsi:type="int" name="nid" nullable="false" unsigned="true" identity="true" comment="n-genius Id"/>
         <column xsi:type="int" name="entity_id" nullable="false" unsigned="true" comment="Entity Id"/>
         <column xsi:type="varchar" name="order_id" nullable="false" length="55" comment="Order Id"/>
-        <column xsi:type="decimal" name="amount" nullable="false" unsigned="true" scale="4" precision="12" comment="Amount"/>
+        <column xsi:type="decimal" name="amount" nullable="false" unsigned="true" scale="4" precision="12"
+                comment="Amount"/>
         <column xsi:type="varchar" name="currency" nullable="false" length="3" comment="Currency"/>
         <column xsi:type="varchar" name="reference" nullable="false" comment="Reference"/>
         <column xsi:type="varchar" name="action" nullable="false" length="20" comment="Action"/>
         <column xsi:type="varchar" name="state" nullable="false" length="20" comment="State"/>
         <column xsi:type="varchar" name="status" nullable="false" length="50" comment="Status"/>
-        <column xsi:type="timestamp" name="created_at" nullable="false" default="CURRENT_TIMESTAMP" comment="Created At"/>
+        <column xsi:type="timestamp" name="created_at" nullable="false" default="CURRENT_TIMESTAMP"
+                comment="Created At"/>
         <column xsi:type="varchar" name="payment_id" nullable="false" comment="Payment Id"/>
-        <column xsi:type="decimal" name="captured_amt" nullable="false" unsigned="true" scale="4" precision="12" comment="Captured Amount"/>
+        <column xsi:type="decimal" name="captured_amt" nullable="false" unsigned="true" scale="4" precision="12"
+                comment="Captured Amount"/>
         <constraint xsi:type="primary" referenceId="PRIMARY">
             <column name="nid"/>
         </constraint>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0"?>
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
 
-    <preference for="Magento\Sales\Model\Order\Email\Sender\OrderSender" type="NetworkInternational\NGenius\Model\Email\OrderSender"/>
+    <preference for="Magento\Sales\Model\Order\Email\Sender\OrderSender"
+                type="NetworkInternational\NGenius\Model\Email\OrderSender"/>
     <type name="Magento\Quote\Observer\Webapi\SubmitObserver">
         <arguments>
-            <argument name="orderSender" xsi:type="object">NetworkInternational\NGenius\Model\Email\OrderSender</argument>
+            <argument name="orderSender" xsi:type="object">NetworkInternational\NGenius\Model\Email\OrderSender
+            </argument>
         </arguments>
     </type>
 
@@ -19,7 +22,8 @@
         </arguments>
     </virtualType>
 
-    <virtualType name="NGeniusCaptureStrategyCommand" type="NetworkInternational\NGenius\Gateway\Command\CaptureStrategyCommand">
+    <virtualType name="NGeniusCaptureStrategyCommand"
+                 type="NetworkInternational\NGenius\Gateway\Command\CaptureStrategyCommand">
         <arguments>
             <argument name="commandPool" xsi:type="object">NGeniusCommandPool</argument>
         </arguments>
@@ -28,7 +32,8 @@
     <!-- Configuration reader -->
     <type name="NetworkInternational\NGenius\Gateway\Config\Config">
         <arguments>
-            <argument name="methodCode" xsi:type="const">\NetworkInternational\NGenius\Gateway\Config\Config::CODE</argument>
+            <argument name="methodCode" xsi:type="const">\NetworkInternational\NGenius\Gateway\Config\Config::CODE
+            </argument>
         </arguments>
     </type>
 
@@ -62,29 +67,45 @@
     <!-- Capture command -->
     <virtualType name="NGeniusCaptureCommand" type="Magento\Payment\Gateway\Command\GatewayCommand">
         <arguments>
-            <argument name="requestBuilder" xsi:type="object">NetworkInternational\NGenius\Gateway\Request\CaptureRequest</argument>
-            <argument name="transferFactory" xsi:type="object">NetworkInternational\NGenius\Gateway\Http\TransferFactory</argument>
-            <argument name="client" xsi:type="object">NetworkInternational\NGenius\Gateway\Http\Client\TransactionCapture</argument>
-            </arguments>
+            <argument name="requestBuilder" xsi:type="object">
+                NetworkInternational\NGenius\Gateway\Request\CaptureRequest
+            </argument>
+            <argument name="transferFactory" xsi:type="object">
+                NetworkInternational\NGenius\Gateway\Http\TransferFactory
+            </argument>
+            <argument name="client" xsi:type="object">
+                NetworkInternational\NGenius\Gateway\Http\Client\TransactionCapture
+            </argument>
+        </arguments>
     </virtualType>
 
 
     <!-- Void command -->
     <virtualType name="NGeniusVoidCommand" type="Magento\Payment\Gateway\Command\GatewayCommand">
         <arguments>
-            <argument name="requestBuilder" xsi:type="object">NetworkInternational\NGenius\Gateway\Request\VoidRequest</argument>
-            <argument name="transferFactory" xsi:type="object">NetworkInternational\NGenius\Gateway\Http\TransferFactory</argument>
-            <argument name="client" xsi:type="object">NetworkInternational\NGenius\Gateway\Http\Client\TransactionVoid</argument>
-            </arguments>
+            <argument name="requestBuilder" xsi:type="object">NetworkInternational\NGenius\Gateway\Request\VoidRequest
+            </argument>
+            <argument name="transferFactory" xsi:type="object">
+                NetworkInternational\NGenius\Gateway\Http\TransferFactory
+            </argument>
+            <argument name="client" xsi:type="object">NetworkInternational\NGenius\Gateway\Http\Client\TransactionVoid
+            </argument>
+        </arguments>
     </virtualType>
 
     <!-- Refund Command -->
     <virtualType name="NGeniusRefundCommand" type="Magento\Payment\Gateway\Command\GatewayCommand">
         <arguments>
-            <argument name="requestBuilder" xsi:type="object">NetworkInternational\NGenius\Gateway\Request\RefundRequest</argument>
-            <argument name="transferFactory" xsi:type="object">NetworkInternational\NGenius\Gateway\Http\TransferFactory</argument>
-            <argument name="client" xsi:type="object">NetworkInternational\NGenius\Gateway\Http\Client\TransactionRefund</argument>
-            </arguments>
+            <argument name="requestBuilder" xsi:type="object">
+                NetworkInternational\NGenius\Gateway\Request\RefundRequest
+            </argument>
+            <argument name="transferFactory" xsi:type="object">
+                NetworkInternational\NGenius\Gateway\Http\TransferFactory
+            </argument>
+            <argument name="client" xsi:type="object">
+                NetworkInternational\NGenius\Gateway\Http\Client\TransactionRefund
+            </argument>
+        </arguments>
     </virtualType>
     <!-- END Refund Command -->
 
@@ -98,7 +119,8 @@
     </virtualType>
     <virtualType name="NGeniusConfigValueHandler" type="Magento\Payment\Gateway\Config\ConfigValueHandler">
         <arguments>
-            <argument name="configInterface" xsi:type="object">NetworkInternational\NGenius\Gateway\Config\Config</argument>
+            <argument name="configInterface" xsi:type="object">NetworkInternational\NGenius\Gateway\Config\Config
+            </argument>
         </arguments>
     </virtualType>
 

--- a/etc/frontend/events.xml
+++ b/etc/frontend/events.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
     <event name="controller_action_predispatch_checkout_index_index">
-        <observer name="initiate_checkout_onepage" instance="NetworkInternational\NGenius\Observer\ProductSaveAfter" />
+        <observer name="initiate_checkout_onepage" instance="NetworkInternational\NGenius\Observer\ProductSaveAfter"/>
     </event>
 </config>

--- a/etc/frontend/routes.xml
+++ b/etc/frontend/routes.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" ?>
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:App/etc/routes.xsd">
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:App/etc/routes.xsd">
     <router id="standard">
         <route frontName="networkinternational" id="networkinternational">
             <module name="NetworkInternational_NGenius"/>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,9 +1,10 @@
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="NetworkInternational_NGenius" setup_version="1.1.3" >
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="NetworkInternational_NGenius" setup_version="1.1.4">
         <sequence>
-            <module name="Magento_Sales" />
-            <module name="Magento_Payment" />
-            <module name="Magento_Checkout" />
+            <module name="Magento_Sales"/>
+            <module name="Magento_Payment"/>
+            <module name="Magento_Checkout"/>
         </sequence>
     </module>
 </config>

--- a/view/adminhtml/layout/ngenius_core_report.xml
+++ b/view/adminhtml/layout/ngenius_core_report.xml
@@ -1,17 +1,21 @@
 <?xml version="1.0"?>
-<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="content">
             <block class="NetworkInternational\NGenius\Block\Adminhtml\Core" name="ngenius_core_report.grid.container">
                 <block class="Magento\Backend\Block\Widget\Grid" name="ngenius_core_report.grid" as="grid">
                     <arguments>
                         <argument name="id" xsi:type="string">ngenius_core_report_grid</argument>
-                        <argument name="dataSource" xsi:type="object">NetworkInternational\NGenius\Model\ResourceModel\Core\Collection</argument>
+                        <argument name="dataSource" xsi:type="object">
+                            NetworkInternational\NGenius\Model\ResourceModel\Core\Collection
+                        </argument>
                         <argument name="default_sort" xsi:type="string">order_id</argument>
                         <argument name="default_dir" xsi:type="string">desc</argument>
                         <argument name="pager_visibility" xsi:type="string">1</argument>
                     </arguments>
-                    <block class="Magento\Backend\Block\Widget\Grid\ColumnSet" as="grid.columnSet" name="ngenius_core_report.grid.columnSet">
+                    <block class="Magento\Backend\Block\Widget\Grid\ColumnSet" as="grid.columnSet"
+                           name="ngenius_core_report.grid.columnSet">
                         <arguments>
                             <argument name="filter_visibility" xsi:type="string">1</argument>
                         </arguments>

--- a/view/frontend/layout/checkout_index_index.xml
+++ b/view/frontend/layout/checkout_index_index.xml
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="checkout.root">
             <arguments>
@@ -24,10 +25,14 @@
                                                             <!-- merge payment method renders here -->
                                                             <item name="children" xsi:type="array">
                                                                 <item name="ngeniusonline" xsi:type="array">
-                                                                    <item name="component" xsi:type="string">NetworkInternational_NGenius/js/view/payment/ngeniusonline</item>
+                                                                    <item name="component" xsi:type="string">
+                                                                        NetworkInternational_NGenius/js/view/payment/ngeniusonline
+                                                                    </item>
                                                                     <item name="methods" xsi:type="array">
                                                                         <item name="ngeniusonline" xsi:type="array">
-                                                                            <item name="isBillingAddressRequired" xsi:type="boolean">true</item>
+                                                                            <item name="isBillingAddressRequired"
+                                                                                  xsi:type="boolean">true
+                                                                            </item>
                                                                         </item>
                                                                     </item>
                                                                 </item>

--- a/view/frontend/web/js/view/payment/method-renderer/ngeniusonline.js
+++ b/view/frontend/web/js/view/payment/method-renderer/ngeniusonline.js
@@ -1,22 +1,22 @@
 define(
-    [   'jquery',
-            'Magento_Checkout/js/view/payment/default',
-            'mage/url'
-        ],
-    function ($, Component, url) {
-            'use strict';
+  ['jquery',
+    'Magento_Checkout/js/view/payment/default',
+    'mage/url'
+  ],
+  function ($, Component, url) {
+    'use strict'
 
-            return Component.extend(
-                {
-                    defaults: {
-                        template: 'NetworkInternational_NGenius/payment/ngeniusonline',
-                        redirectAfterPlaceOrder: false
-                    },
-                    afterPlaceOrder: function () {
-                        $('#ngenius_redirect_msg').show();
-                        window.location.replace(url.build('networkinternational/ngeniusonline/redirect'));
-                    }
-                    }
-            );
-    }
-);
+    return Component.extend(
+      {
+        defaults: {
+          template: 'NetworkInternational_NGenius/payment/ngeniusonline',
+          redirectAfterPlaceOrder: false
+        },
+        afterPlaceOrder: function () {
+          $('#ngenius_redirect_msg').show()
+          window.location.replace(url.build('networkinternational/ngeniusonline/redirect'))
+        }
+      }
+    )
+  }
+)

--- a/view/frontend/web/js/view/payment/ngeniusonline.js
+++ b/view/frontend/web/js/view/payment/ngeniusonline.js
@@ -1,21 +1,21 @@
 define(
-    [
-        'uiComponent',
-        'Magento_Checkout/js/model/payment/renderer-list'
-    ],
-    function (Component, rendererList) {
-        'use strict';
+  [
+    'uiComponent',
+    'Magento_Checkout/js/model/payment/renderer-list'
+  ],
+  function (Component, rendererList) {
+    'use strict'
 
-        rendererList.push(
-            {
-                type: 'ngeniusonline',
-                component: 'NetworkInternational_NGenius/js/view/payment/method-renderer/ngeniusonline'
-            }
-        );
+    rendererList.push(
+      {
+        type: 'ngeniusonline',
+        component: 'NetworkInternational_NGenius/js/view/payment/method-renderer/ngeniusonline'
+      }
+    )
 
-        /**
-    * Add view logic here if needed
-    */
-        return Component.extend({});
-    }
-);
+    /**
+     * Add view logic here if needed
+     */
+    return Component.extend({})
+  }
+)


### PR DESCRIPTION
- Add VISA additional mandatory fields to the Order API Request Body.
- Don't allow OrderCancelAfter Observer to trigger for other payment methods.
- Don't allow Cron to process orders created by other payment methods.
- Change the cron table from ngenius_networkinternational to ngenius_networkinternational_sales_order to avoid the processing of historic orders.
- Fix Cron order processing of abandoned APM methods in a state of AWAIT_3DS.
- Improve payment action support for China Union Pay.