### PR TITLE
[1.4.1]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [[1.4.1]](https://github.com/network-international/ngenius-magento-plugin/releases/tag/1.4.1)
+
+### Fixed
+
+- Partial refund processing logic to correctly distinguish between fully refunded and partially refunded transactions.
+  Refund status determination is now based on the original captured amount rather than remaining captured values,
+  ensuring partially refunded orders are no longer incorrectly marked as fully refunded.
+- Cron job configuration: Disabled separate process execution (`use_separate_process` changed from 1 to 0) to resolve
+  potential process isolation issues.
+- Error handling in Payment controller: Now checks error status from both `NgeniusApiService` and `OrderStatusService`
+  for more comprehensive error detection.
+- AWAIT3DS state handling: Included AWAIT3DS state in cron queries for started orders to properly process abandoned
+  orders awaiting 3DS authentication.
+- Order state persistence: Implemented direct database updates for order state/status in scenarios where DataObject
+  save methods are unavailable, ensuring state changes are properly recorded.
+- Observer safety checks: Added null/empty data validation in `OrderAuthCaptured` observer to prevent errors when
+  processing orders with missing or incomplete data.
+
+### Improved
+
+- State management: Added `getNgeniusState()` and `setNgeniusState()` methods to `NgeniusApiService` and
+  `OrderStatusService` for better state tracking and consistency across payment processing workflows.
+- Error detection: Added `getIsError()` methods to both API and order status services, providing standardized error
+  state access throughout the payment flow.
+
 ## [[1.4.0]](https://github.com/network-international/ngenius-magento-plugin/releases/tag/1.4.0)
 
 ### Added

--- a/Controller/NGeniusOnline/Payment.php
+++ b/Controller/NGeniusOnline/Payment.php
@@ -323,11 +323,15 @@ class Payment implements HttpGetActionInterface
                     $action = $result['action'] ?? '';
 
                     $apiProcessor = new ApiProcessor($result);
-                    $apiProcessor->processPaymentAction($action, $this->ngeniusState);
+
+                    $ngeniusState = $this->ngeniusApiService->getNgeniusState();
+                    $apiProcessor->processPaymentAction($action, $ngeniusState);
+
                     $orderItemObject = new DataObject($orderItem);
+                    $this->orderStatusService->setNgeniusState($ngeniusState);
                     $this->orderStatusService->processOrder($apiProcessor, $orderItemObject, $action);
                 }
-                if ($this->error) {
+                if ($this->ngeniusApiService->getIsError() || $this->orderStatusService->getIsError()) {
                     $this->messageManager->addErrorMessage(
                         __(
                             'Failed! There is an issue with your payment transaction. '
@@ -393,7 +397,7 @@ class Payment implements HttpGetActionInterface
 
         $startedOrdersSelect = $connection->select()
             ->from($tableName)
-            ->where('state = ?', self::NGENIUS_STARTED)
+            ->where('state IN (?, ?)', [self::NGENIUS_STARTED, self::NGENIUS_AWAIT3DS])
             ->where('created_at <= ?', date('Y-m-d H:i:s', strtotime('-1 hour')))
             ->order('nid DESC');
 

--- a/Gateway/Http/Client/TransactionRefund.php
+++ b/Gateway/Http/Client/TransactionRefund.php
@@ -61,19 +61,21 @@ class TransactionRefund extends PaymentTransaction
             $state = $responseArray['state'] ?? '';
 
             if ($state === 'REVERSED') {
-                $capturedAmount = $orderItem->getData('captured_amt');
+                $capturedAmount = (float)$orderItem->getData('captured_amt');
                 $orderItem->addData(['REVERSED' => 'REVERSED']);
             }
 
-            if ($capturedAmount == 0) {
+            $originalCapturedAmount = (float)$orderItem->getData('captured_amt');
+
+            if ($totalRefunded <= 0) {
                 $orderStatus = $this->orderStatus[7]['status'];
-                $orderItem->setCaptureAmt(0);
-            } elseif ($capturedAmount === $totalRefunded) {
+                $orderItem->setCapturedAmt($originalCapturedAmount);
+            } elseif ($totalRefunded >= $originalCapturedAmount) {
                 $orderStatus = $this->orderStatus[7]['status'];
-                $orderItem->setCapturedAmt(($capturedAmount - $totalRefunded));
+                $orderItem->setCapturedAmt(0);
             } else {
                 $orderStatus = $this->orderStatus[8]['status'];
-                $orderItem->setCapturedAmt(($capturedAmount - $totalRefunded));
+                $orderItem->setCapturedAmt($originalCapturedAmount - $totalRefunded);
             }
 
             $orderItem->setState(DataPatch::STATE);

--- a/Helper/Version.php
+++ b/Helper/Version.php
@@ -12,7 +12,7 @@ class Version
      *
      * @var string
      */
-    public const MODULE_VERSION = '1.4.0';
+    public const MODULE_VERSION = '1.4.1';
 
     /**
      * Retrieves the module version.

--- a/Observer/OrderAuthCaptured.php
+++ b/Observer/OrderAuthCaptured.php
@@ -45,16 +45,19 @@ class OrderAuthCaptured implements ObserverInterface
             $orderRef
         );
         $orderItem  = $collection->getFirstItem();
+        $orderData  = $orderItem->getData();
 
-        if ($orderItem->getData()["action"] !== "AUTH"
-            || (int)($orderItem->getData()["captured_amt"]) === 0
+        if (empty($orderData)
+            || !isset($orderData["action"])
+            || $orderData["action"] !== "AUTH"
+            || (int)($orderData["captured_amt"] ?? 0) === 0
         ) {
             return;
         }
 
-        if ($order->canShip()) {
-            $order->setState($orderItem->getData()["state"]);
-            $order->setStatus($orderItem->getData()["status"]);
+        if ($order->canShip() && isset($orderData["state"]) && isset($orderData["status"])) {
+            $order->setState($orderData["state"]);
+            $order->setStatus($orderData["status"]);
             $order->save();
         }
     }

--- a/Service/NgeniusApiService.php
+++ b/Service/NgeniusApiService.php
@@ -141,6 +141,16 @@ class NgeniusApiService
     }
 
     /**
+     * Gets the error status of the API interaction.
+     *
+     * @return string|null The error status or null if not set.
+     */
+    public function getIsError(): ?string
+    {
+        return $this->error ?? null;
+    }
+
+    /**
      * Validates the API result.
      *
      * @param array $result The API result to validate.
@@ -159,5 +169,26 @@ class NgeniusApiService
 
             return $result;
         }
+    }
+
+    /**
+     * Gets the current N-Genius state.
+     *
+     * @return string|null
+     */
+    public function getNgeniusState(): ?string
+    {
+        return $this->ngeniusState ?? null;
+    }
+
+    /**
+     * Sets the N-Genius state.
+     *
+     * @param string $state
+     * @return void
+     */
+    public function setNgeniusState(string $state): void
+    {
+        $this->ngeniusState = $state;
     }
 }

--- a/Service/OrderStatusService.php
+++ b/Service/OrderStatusService.php
@@ -273,6 +273,29 @@ class OrderStatusService
 
             $orderItem->setData('state', 'cron');
             $orderItem->setData('status', 'cron');
+            // Direct DB update for state/status
+            $connection = $this->resourceConnection->getConnection();
+            $tableName  = $connection->getTableName('ngenius_networkinternational_sales_order');
+            $nid        = null;
+            if (method_exists($orderItem, 'getNid')) {
+                $nid = $orderItem->getNid();
+            }
+            if (!$nid && method_exists($orderItem, 'getData')) {
+                $nid = $orderItem->getData('nid');
+            }
+            if (!$nid && property_exists($orderItem, 'nid')) {
+                $nid = $orderItem->nid;
+            }
+            if ($nid) {
+                $updateData = [
+                    'state'  => 'cron',
+                    'status' => 'cron',
+                ];
+                $where      = $connection->quoteInto('nid = ?', $nid);
+                $connection->update($tableName, $updateData, $where);
+            } else {
+                $this->logger->error("N-GENIUS: processNormalOrders missing nid for direct DB update");
+            }
 
             $orderRef    = (string)($orderItem->getData('reference') ?? $orderItem->getReference());
             $incrementId = (string)($orderItem->getData('order_id') ?? $orderItem->getOrderId());
@@ -312,7 +335,9 @@ class OrderStatusService
                         ],
                         true
                     )) {
-                        $this->ngeniusState = self::NGENIUS_FAILED;
+                        $this->setNgeniusState(self::NGENIUS_FAILED);
+                    } else {
+                        $this->setNgeniusState($paymentState);
                     }
 
                     $this->processOrder($apiProcessor, $orderItem, $action);
@@ -435,7 +460,7 @@ class OrderStatusService
                 $dataTable['captured_amt'] = $this->orderSale($order, $paymentResult, $paymentId);
             }
             $dataTable['status'] = $order->getStatus();
-        } elseif ($this->ngeniusState === self::NGENIUS_STARTED) {
+        } elseif ($this->ngeniusState === self::NGENIUS_STARTED || $this->ngeniusState === self::NGENIUS_AWAIT3DS) {
             $dataTable['status'] = Order::STATE_PENDING_PAYMENT;
         } else {
             // Authorisation has failed - cancel order
@@ -665,18 +690,36 @@ class OrderStatusService
             return;
         }
 
-        $paymentId          = $apiProcessor->getPaymentId();
-        $paymentResult      = $apiProcessor->getPaymentResult();
-        $this->ngeniusState = strtoupper($paymentResult['state'] ?? '');
+        $paymentId = $apiProcessor->getPaymentId();
 
         $order   = $this->orderFactory->create()->loadByIncrementId($incrementId);
         $storeId = $order->getStoreId();
 
         if (!$order->getId()) {
-            $orderItem->setPaymentId($paymentId);
-            $orderItem->setState($this->ngeniusState);
-            $orderItem->setStatus($this->ngeniusState);
-            $orderItem->save();
+            // Update the DB directly since DataObject has no save()
+            $connection = $this->resourceConnection->getConnection();
+            $tableName  = $connection->getTableName('ngenius_networkinternational_sales_order');
+            $nid        = null;
+            if (method_exists($orderItem, 'getNid')) {
+                $nid = $orderItem->getNid();
+            }
+            if (!$nid && method_exists($orderItem, 'getData')) {
+                $nid = $orderItem->getData('nid');
+            }
+            if (!$nid && property_exists($orderItem, 'nid')) {
+                $nid = $orderItem->nid;
+            }
+            if ($nid) {
+                $updateData = [
+                    'payment_id' => $paymentId,
+                    'state'      => $this->ngeniusState,
+                    'status'     => $this->ngeniusState,
+                ];
+                $where      = $connection->quoteInto('nid = ?', $nid);
+                $connection->update($tableName, $updateData, $where);
+            } else {
+                $this->logger->error("N-GENIUS: processOrder missing nid for direct DB update");
+            }
             return;
         }
 
@@ -817,5 +860,36 @@ class OrderStatusService
             $this->logger->error("N-GENIUS: Failed to update table: " . $e->getMessage());
             return false;
         }
+    }
+
+    /**
+     * Gets the current N-Genius state.
+     *
+     * @return string|null
+     */
+    public function getNgeniusState(): ?string
+    {
+        return $this->ngeniusState ?? null;
+    }
+
+    /**
+     * Sets the N-Genius state.
+     *
+     * @param string $state
+     * @return void
+     */
+    public function setNgeniusState(string $state): void
+    {
+        $this->ngeniusState = $state;
+    }
+
+    /**
+     * Gets the error status of the API interaction.
+     *
+     * @return string|null The error status or null if not set.
+     */
+    public function getIsError(): ?string
+    {
+        return $this->error ?? null;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "networkinternational/ngenius",
   "description": "N-Genius Online by Network Payment Gateway for Magento 2",
   "type": "magento2-module",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "minimum-stability": "stable",
   "license": "GPL-3.0",
   "authors": [

--- a/etc/cron_groups.xml
+++ b/etc/cron_groups.xml
@@ -8,6 +8,6 @@
         <history_cleanup_every>10</history_cleanup_every>
         <history_success_lifetime>60</history_success_lifetime>
         <history_failure_lifetime>600</history_failure_lifetime>
-        <use_separate_process>1</use_separate_process>
+        <use_separate_process>0</use_separate_process>
     </group>
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="NetworkInternational_NGenius" setup_version="1.4.0">
+    <module name="NetworkInternational_NGenius" setup_version="1.4.1">
         <sequence>
             <module name="Magento_Sales"/>
             <module name="Magento_Payment"/>


### PR DESCRIPTION
### Fixed

- Partial refund processing logic to correctly distinguish between fully refunded and partially refunded transactions. Refund status determination is now based on the original captured amount rather than remaining captured values, ensuring partially refunded orders are no longer incorrectly marked as fully refunded.
- Cron job configuration: Disabled separate process execution (`use_separate_process` changed from 1 to 0) to resolve potential process isolation issues.
- Error handling in Payment controller: Now checks error status from both `NgeniusApiService` and `OrderStatusService` for more comprehensive error detection.
- AWAIT3DS state handling: Included AWAIT3DS state in cron queries for started orders to properly process abandoned orders awaiting 3DS authentication.
- Order state persistence: Implemented direct database updates for order state/status in scenarios where DataObject save methods are unavailable, ensuring state changes are properly recorded.
- Observer safety checks: Added null/empty data validation in `OrderAuthCaptured` observer to prevent errors when processing orders with missing or incomplete data.

### Improved

- State management: Added `getNgeniusState()` and `setNgeniusState()` methods to `NgeniusApiService` and `OrderStatusService` for better state tracking and consistency across payment processing workflows.
- Error detection: Added `getIsError()` methods to both API and order status services, providing standardized error state access throughout the payment flow.